### PR TITLE
Fixes oceanographer_ec firmware

### DIFF
--- a/firmware-work in progress/oceanographer_ec/config.h
+++ b/firmware-work in progress/oceanographer_ec/config.h
@@ -30,13 +30,15 @@
 //#define ECSM_TUNE_ON_BOOT
 
 /* key matrix size */
-#define MATRIX_ROWS 4
+#define MATRIX_ROWS 5
 #define MATRIX_COLS 12
+#define EC_MATRIX_ROWS 4
+#define EC_MATRIX_COLS MATRIX_COLS
 
 /* Custom matrix pins and port select array */
-#define MATRIX_ROW_PINS \
+#define EC_MATRIX_ROW_PINS \
     { B14, B15, B12, B13 }
-#define MATRIX_COL_CHANNELS \
+#define EC_MATRIX_COL_CHANNELS \
     { \
        2, 1, 0, 3, 5, 4, \
        10, 9, 8, 11, 13, 12 \
@@ -51,9 +53,6 @@
 
 #define DISCHARGE_PIN A4
 #define ANALOG_PORT A3
-
-/* COL2ROW, ROW2COL */
-#define DIODE_DIRECTION COL2ROW
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 //#define DEBOUNCE 5

--- a/firmware-work in progress/oceanographer_ec/ec_switch_matrix.c
+++ b/firmware-work in progress/oceanographer_ec/ec_switch_matrix.c
@@ -22,16 +22,16 @@
 #include "print.h"
 
 /* Pin and port array */
-const uint32_t row_pins[]     = MATRIX_ROW_PINS;
-const uint8_t  col_channels[] = MATRIX_COL_CHANNELS;
+const uint32_t row_pins[]     = EC_MATRIX_ROW_PINS;
+const uint8_t  col_channels[] = EC_MATRIX_COL_CHANNELS;
 const uint32_t mux_sel_pins[] = MUX_SEL_PINS;
 const uint32_t mux_en_pins[] =  MUX_EN_PINS;
 
 static adc_mux adcMux;
-static uint16_t ecsm_sw_value[MATRIX_ROWS][MATRIX_COLS];
+static uint16_t ecsm_sw_value[EC_MATRIX_ROWS][EC_MATRIX_COLS];
 
-static ecsm_threshold_t ecsm_thresholds[MATRIX_ROWS][MATRIX_COLS];
-static int16_t ecsm_tuning_data[MATRIX_ROWS][MATRIX_COLS];
+static ecsm_threshold_t ecsm_thresholds[EC_MATRIX_ROWS][EC_MATRIX_COLS];
+static int16_t ecsm_tuning_data[EC_MATRIX_ROWS][EC_MATRIX_COLS];
 static uint32_t ecsm_is_tuning = 1e5; // Tunes ec config until this counter reaches 0
 
 /* fancy printing */
@@ -74,7 +74,7 @@ static inline void select_col(uint8_t col) {
 
 /// @brief hardware initialization for row pins
 static inline void init_row(void) {
-    for (int i = 0; i < MATRIX_ROWS; i++) {
+    for (int i = 0; i < EC_MATRIX_ROWS; i++) {
         setPinOutput(row_pins[i]);
         writePinLow(row_pins[i]);
     }
@@ -93,8 +93,8 @@ static inline void init_mux(void) {
 
 void ecsm_config_init(void) {
     eeconfig_read_kb_datablock(&ecsm_config);
-    for (int i = 0; i < MATRIX_ROWS; i++) {
-        for (int j = 0; j < MATRIX_COLS; j++) {
+    for (int i = 0; i < EC_MATRIX_ROWS; i++) {
+        for (int j = 0; j < EC_MATRIX_COLS; j++) {
             if (! ecsm_config.configured) {
                 // fallback to default values
                 ecsm_config.actuation_offset = ACTUATION_OFFSET;
@@ -108,8 +108,8 @@ void ecsm_config_init(void) {
 }
 
 void ecsm_config_update(void) {
-    for (int i = 0; i < MATRIX_ROWS; i++) {
-        for (int j = 0; j < MATRIX_COLS; j++) {
+    for (int i = 0; i < EC_MATRIX_ROWS; i++) {
+        for (int j = 0; j < EC_MATRIX_COLS; j++) {
             ecsm_config.idle[i][j] = ecsm_tuning_data[i][j];
         }
     }
@@ -124,8 +124,8 @@ void ecsm_eeprom_clear(void) {
     ecsm_config.configured = 0;
     ecsm_config.actuation_offset = ACTUATION_OFFSET;
     ecsm_config.release_offset = RELEASE_OFFSET;
-    for (int i = 0; i < MATRIX_ROWS; i++) {
-        for (int j = 0; j < MATRIX_COLS; j++) {
+    for (int i = 0; i < EC_MATRIX_ROWS; i++) {
+        for (int j = 0; j < EC_MATRIX_COLS; j++) {
             ecsm_config.idle[i][j] = 0;
         }
     }
@@ -192,8 +192,8 @@ void ecsm_update_tuning_data(int16_t new_value, uint8_t row, uint8_t col) {
 }
 
 void ecsm_update_thresholds(void) {
-    for (int i = 0; i < MATRIX_ROWS; i++) {
-        for (int j = 0; j < MATRIX_COLS; j++) {
+    for (int i = 0; i < EC_MATRIX_ROWS; i++) {
+        for (int j = 0; j < EC_MATRIX_COLS; j++) {
             int16_t idle = ecsm_tuning_data[i][j];
             ecsm_thresholds[i][j].actuation =  idle + ecsm_config.actuation_offset;
             ecsm_thresholds[i][j].release = idle + ecsm_config.release_offset;
@@ -239,9 +239,9 @@ bool ecsm_update_key(matrix_row_t* current_row, uint8_t row, uint8_t col, uint16
 
 void ecsm_print_matrix(matrix_row_t current_matrix[]) {
     uprintln();
-    for (int i = 0; i < MATRIX_ROWS; i++) {
+    for (int i = 0; i < EC_MATRIX_ROWS; i++) {
         uprintf("[ADC readings]: ");
-        for (int j = 0; j < MATRIX_COLS; j++) {
+        for (int j = 0; j < EC_MATRIX_COLS; j++) {
             bool key_pressed = (current_matrix[i] >> j) & 1;
 
             if (key_pressed) {
@@ -266,8 +266,8 @@ void ecsm_print_debug(void) {
     }
 
     uprintf("Current idle readings:\n");
-    for (int i = 0; i < MATRIX_ROWS; i++) {
-        for (int j = 0; j < MATRIX_COLS; j++) {
+    for (int i = 0; i < EC_MATRIX_ROWS; i++) {
+        for (int j = 0; j < EC_MATRIX_COLS; j++) {
             if (!tuned) {
                 uprintf("%4u  ", ecsm_tuning_data[i][j]);
             } else {
@@ -281,8 +281,8 @@ void ecsm_print_debug(void) {
 
     uprintf("\nActuation points:\n");
 
-    for (int i = 0; i < MATRIX_ROWS; i++) {
-        for (int j = 0; j < MATRIX_COLS; j++) {
+    for (int i = 0; i < EC_MATRIX_ROWS; i++) {
+        for (int j = 0; j < EC_MATRIX_COLS; j++) {
             uprintf("%4u  ", ecsm_thresholds[i][j].actuation);
         }
         uprintln();
@@ -295,8 +295,8 @@ void ecsm_print_debug(void) {
 bool ecsm_matrix_scan(matrix_row_t current_matrix[]) {
     bool updated = false;
 
-    for (int col = 0; col < MATRIX_COLS; col++) {
-        for (int row = 0; row < MATRIX_ROWS; row++) {
+    for (int col = 0; col < EC_MATRIX_COLS; col++) {
+        for (int row = 0; row < EC_MATRIX_ROWS; row++) {
             uint16_t adc = ecsm_readkey_raw(row, col);
             ecsm_sw_value[row][col] = adc;
             updated |= ecsm_update_key(&current_matrix[row], row, col, adc);

--- a/firmware-work in progress/oceanographer_ec/halconf.h
+++ b/firmware-work in progress/oceanographer_ec/halconf.h
@@ -1,5 +1,6 @@
 #pragma once
 
 #define HAL_USE_ADC TRUE
+#define HAL_USE_PAL TRUE
 
 #include_next <halconf.h>

--- a/firmware-work in progress/oceanographer_ec/keymaps/vial/keymap.c
+++ b/firmware-work in progress/oceanographer_ec/keymaps/vial/keymap.c
@@ -4,29 +4,33 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-[0] = LAYOUT( \
+[0] = LAYOUT_big_bar( \
   KC_ESC,   KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,     KC_O,    KC_P,     KC_BSPC,  \
   KC_TAB,   KC_A,   KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,     KC_L,    KC_SLASH, KC_ENTER, \
   KC_LSFT,  KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMMA, KC_DOT,  KC_RSFT,  KC_UP, \
-  KC_LCTL, KC_LGUI, KC_LALT,                KC_SPC,                           KC_RALT,  KC_LEFT, KC_DOWN, KC_RIGHT \
+  KC_LCTL, KC_LGUI, KC_LALT,                KC_SPC,                           KC_RALT,  KC_LEFT, KC_DOWN, KC_RIGHT, \
+  KC_NO \
 ),
-[1] = LAYOUT( \
+[1] = LAYOUT_big_bar( \
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
-  KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                            KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+  KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                            KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
+  KC_NO \
 ),
-[2] = LAYOUT( \
+[2] = LAYOUT_big_bar( \
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
-  KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                            KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+  KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                            KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
+  KC_NO \
 ),
-[3] = LAYOUT( \
+[3] = LAYOUT_big_bar( \
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
   KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
-  KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                            KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+  KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS,                            KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, \
+  KC_NO \
 )
 
 };

--- a/firmware-work in progress/oceanographer_ec/matrix.c
+++ b/firmware-work in progress/oceanographer_ec/matrix.c
@@ -19,26 +19,50 @@
 #include "matrix.h"
 #include "print.h"
 
-/* matrix state(1:on, 0:off) */
-extern matrix_row_t raw_matrix[MATRIX_ROWS]; // raw values
-extern matrix_row_t matrix[MATRIX_ROWS];     // debounced values
-extern bool ecsm_update_tuning;
+const uint32_t extra_switch_pins[] =  EXTRA_SWITCH_PINS;
+
+void extra_switch_init(void) {
+    for (int i = 0; i < EXTRA_SWITCHES; i++) {
+        setPinInputHigh(extra_switch_pins[i]);
+    }
+}
 
 void matrix_init_custom(void) {
     ecsm_init();
+    extra_switch_init();
+}
+
+bool extra_switches_scan(matrix_row_t current_matrix[]) {
+    bool updated = false;
+    matrix_row_t prev_row_state = current_matrix[EXTRA_SWITCH_ROW];
+    matrix_row_t curr_row_state = 0;
+
+    for (int i = 0; i < EXTRA_SWITCHES; i++) {
+        uint8_t mask = 1 << i;
+        curr_row_state |= readPin(extra_switch_pins[i]) ? 0 : mask;
+    }
+
+    if (curr_row_state != prev_row_state) {
+        current_matrix[EXTRA_SWITCH_ROW] = curr_row_state;
+        updated = true;
+    }
+
+    return updated;
 }
 
 bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     bool updated = ecsm_matrix_scan(current_matrix);
+    updated |= extra_switches_scan(current_matrix);
 
 #ifdef CONSOLE_ENABLE
     #ifdef ECSM_DEBUG
     static int cnt = 0;
 
-    if (cnt++ == 1000) {
+    if (cnt++ == 500) {
         cnt = 0;
         ecsm_print_debug();
         ecsm_print_matrix(current_matrix);
+        matrix_print();
     }
     #endif
 #endif


### PR DESCRIPTION
- Keymap layout macro needed to match info.json
- `config.h`, `matrix.c` and `ec_switch_matrix.c` updated for the mixed matrix
- vial keymap was missing keycode for the extra switches
- update `halconf.h` for new mcu